### PR TITLE
update compatibility with php 7.2

### DIFF
--- a/src/RollbarComponent.php
+++ b/src/RollbarComponent.php
@@ -2,7 +2,7 @@
 
 namespace accessd\yii2_rollbar;
 
-class RollbarComponent extends \yii\base\Object
+class RollbarComponent extends \yii\base\BaseObject
 {
     // required
     public $accessToken;


### PR DESCRIPTION
Cannot use 'Object' as class name since PHP 7.2
https://github.com/yiisoft/yii2/issues/7936